### PR TITLE
Feat: 한 줄 기록 조회 api 월별 조회 필터 추가, CRUD API 응답 형식 수정 (#43)

### DIFF
--- a/src/controllers/record.controller.js
+++ b/src/controllers/record.controller.js
@@ -8,7 +8,7 @@ export const handleCreateRecord = async (req, res, next) => {
     #swagger.summary = '한 줄 기록 생성 API'
     #swagger.description = '특정 유저의 한 줄 기록을 생성합니다.'
     #swagger.parameters['userId'] = { in: 'path', description: '유저 ID', type: 'integer' }
-    #swagger.parameters['categoryId'] = { ignore: true }
+    #swagger.query['categoryId'] = { ignore: true }
 
     #swagger.requestBody = {
         required: true,
@@ -124,8 +124,11 @@ export const handleGetRecord = async (req, res, next) => {
     /*
     #swagger.tags = ['Record']
     #swagger.summary = '한 줄 기록 조회 API'
-    #swagger.description = '특정 유저의 모든 한 줄 기록을 가져옵니다.'
+    #swagger.description = '특정 유저의 연도와 월에 해당하는 한 줄 기록을 가져옵니다.'
     #swagger.parameters['userId'] = { in: 'path', description: '유저 ID', type: 'integer' }
+    #swagger.parameters['year'] = { in: 'query', required: true, description: '조회할 연도', type: 'integer' }
+    #swagger.parameters['month'] = { in: 'query', required: true, description: '조회할 월', type: 'integer' }
+    
     #swagger.responses[200] = {
         description: "조회 성공 응답",
         schema: {
@@ -170,8 +173,8 @@ export const handleGetRecord = async (req, res, next) => {
 
     try{
         const userId = req.params.userId;
-        const categoryId = req.query.categoryId;
-        const result = await getRecord(getRecordDto({userId, categoryId}))
+        const {year, month, categoryId} = req.query;
+        const result = await getRecord(getRecordDto({userId, categoryId, year, month}))
         res.status(StatusCodes.OK).success(result);
     } catch(err) {
         next(err);

--- a/src/dtos/record.dtos.js
+++ b/src/dtos/record.dtos.js
@@ -38,17 +38,32 @@ export const createRecordDto = (data) => {
 }
 
 export const getRecordDto = (data) => {
-    if(!data.userId) {
+    const errors = [];
+    console.log(data);
+    const requireFields = ["userId", "year", "month"]; 
+
+    for(const field of requireFields){
+        if(!data[field]) errors.push(({field: field, reason: "필드가 누락되었습니다."}));
+    }
+
+    if(Number(data.month) < 1 || Number(data.month) > 12) {
+        errors.push({field: "month", reason: "월은 1-12 사이의 값이어야 합니다."})
+    }
+
+    if(errors.length > 0) {
         const err = new Error("입력값이 유효하지 않습니다.");
         err.statusCode = StatusCodes.BAD_REQUEST;
         err.errorCode = "C001";
-        err.data = {field: "userId", reason: "userId 형식이 올바르지 않습니다"};
+        err.data = errors;
         throw err;
     }
 
+    const paddedMonth = String(data.month).padStart(2, '0');
+
     return {
         userId: Number(data.userId),
-        categoryId: Number(data.categoryId)
+        categoryId: Number(data.categoryId),
+        occurDate: new Date(`${data.year}-${paddedMonth}`)
     }
 }
 

--- a/src/repositories/record.repository.js
+++ b/src/repositories/record.repository.js
@@ -36,6 +36,9 @@ export const createRecord = async (data) => {
 
 // userId, categoryId
 export const getRecords = async (data) => {
+    const nextDate = new Date(data.occurDate);
+    nextDate.setDate(data.occurDate.getDate() + 1);
+
     const records = await prisma.record.findMany({
         select: {
             id: true,
@@ -54,6 +57,10 @@ export const getRecords = async (data) => {
         },
         where: {
             userId: data.userId,
+            occurDate: {
+                gte: data.occurDate,
+                lt: nextDate
+            },
             recordCategories: data.categoryId ? {
                 some: {
                     categoryId: data.categoryId

--- a/src/repositories/record.repository.js
+++ b/src/repositories/record.repository.js
@@ -28,7 +28,10 @@ export const createRecord = async (data) => {
         title: record.title,
         content: record.content,
         occurDate: record.occurDate,
-        categories: record.recordCategories.map(rc => rc.categories.categoryName)
+        categories: record.recordCategories.map(rc => ({
+            categoryId: rc.categories.id, 
+            categoryName: rc.categories.categoryName
+        }))
     }
 
     return formattedRecord;
@@ -49,6 +52,7 @@ export const getRecords = async (data) => {
                 select: {
                     categories: {
                         select: {
+                            id: true,
                             categoryName: true
                         }
                     }
@@ -77,7 +81,10 @@ export const getRecords = async (data) => {
         title: record.title,
         content: record.content,
         occurDate: record.occurDate,
-        categories: record.recordCategories.map(rc => rc.categories.categoryName)
+        categories: record.recordCategories.map(rc => ({
+            categoryId: rc.categories.id, 
+            categoryName: rc.categories.categoryName
+        }))
     }));
 
     return formattedRecords;
@@ -115,7 +122,10 @@ export const updateRecord = async (data) => {
         title: record.title,
         content: record.content,
         occurDate: record.occurDate,
-        categories: record.recordCategories.map(rc => rc.categories.categoryName)
+        categories: record.recordCategories.map(rc => ({
+            categoryId: rc.categories.id, 
+            categoryName: rc.categories.categoryName
+        }))
     }
     return formattedRecord;
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [ ] 기능 추가
- [ ] 기능 수정
- [ ] 스웨거 작성

### 반영 브랜치

ex) feature/43-한줄기록조회api월별조회필터추가-> develop

### 변경 사항

- 조회 api에서 특정 연도, 월 조회 필터를 추가했습니다.
- CRUD에서 기존 카테고리 이름만 응답했던거에서 이름과 id를 같이 반환하게 수정했습니다.

### 테스트 결과

ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.
